### PR TITLE
FS2-2771: Fix color scale colors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhtmlCombinedScatter
 Type: Package
 Title: An HTML widget that creates a labeled scatter plot
-Version: 1.0.10
+Version: 1.0.11
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: An HTML widget that creates a labeled scatter plot.

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -423,7 +423,7 @@ CombinedScatter <- function(
             color.levels <- levels(tmp)
             tmp.seq <- seq(from = 0, to = 1, length = nlevels(tmp))
             color.scale <- rgb(color.func(tmp.seq), maxColorValue = 255)
-            color.tmp <- unique(as.numeric(tmp)
+            color.tmp <- unique(as.numeric(tmp))
             group <- as.numeric(tmp)
         }
         color.min <- min(color.tmp, na.rm = TRUE)

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -411,7 +411,7 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.func <- colorRamp(color.scale)
+        color.func <- colorRamp(unique(color.scale)) # undo recycling in PrepareColors
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
             color.tmp <- as.numeric(group)

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -411,23 +411,26 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.func <- colorRamp(unique(color.scale)) # undo recycling in PrepareColors
+        color.scale <- unique(color.scale) # undo recycling in PrepareColors
+        color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
-            color.tmp <- as.numeric(group)
+            color.tmp <- unique(as.numeric(group)
         } else if (is.numeric(group)) {
-            color.tmp <- group
+            color.tmp <- unique(group)
         } else {
             tmp <- as.factor(group)
             color.levels <- levels(tmp)
             tmp.seq <- seq(from = 0, to = 1, length = nlevels(tmp))
             color.scale <- rgb(color.func(tmp.seq), maxColorValue = 255)
-            color.tmp <- as.numeric(tmp)
-            group <- color.tmp
+            color.tmp <- unique(as.numeric(tmp)
+            group <- as.numeric(tmp)
         }
+        color.min <- min(color.tmp, na.rm = TRUE)
+        color.max <- max(color.tmp, na.rm = TRUE)
 
         # Convert color variable to scale on 0 to 1
-        colors.scaled <- seq(from = 0, to = 1, length = length(color.levels))
+        colors.scaled <- (color.tmp - color.min)/(color.max - color.min)
         colors <- rgb(color.func(colors.scaled), maxColorValue = 255)
 
         # Use existing color interpolation to reduce the number

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -411,7 +411,6 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.scale <- unique(color.scale) # undo recycling in PrepareColors
         color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -425,11 +425,9 @@ CombinedScatter <- function(
             color.tmp <- as.numeric(tmp)
             group <- color.tmp
         }
-        color.min <- min(color.tmp, na.rm = TRUE)
-        color.max <- max(color.tmp, na.rm = TRUE)
 
         # Convert color variable to scale on 0 to 1
-        colors.scaled <- (color.tmp - color.min)/(color.max - color.min)
+        colors.scaled <- seq(from = 0, to = 1, length = length(color.levels))
         colors <- rgb(color.func(colors.scaled), maxColorValue = 255)
 
         # Use existing color interpolation to reduce the number

--- a/R/rhtmlCombinedScatter.R
+++ b/R/rhtmlCombinedScatter.R
@@ -415,7 +415,7 @@ CombinedScatter <- function(
         color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
-            color.tmp <- unique(as.numeric(group)
+            color.tmp <- unique(as.numeric(group))
         } else if (is.numeric(group)) {
             color.tmp <- unique(group)
         } else {

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -423,7 +423,7 @@ CombinedScatter <- function(
             color.levels <- levels(tmp)
             tmp.seq <- seq(from = 0, to = 1, length = nlevels(tmp))
             color.scale <- rgb(color.func(tmp.seq), maxColorValue = 255)
-            color.tmp <- unique(as.numeric(tmp)
+            color.tmp <- unique(as.numeric(tmp))
             group <- as.numeric(tmp)
         }
         color.min <- min(color.tmp, na.rm = TRUE)

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -411,7 +411,7 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.func <- colorRamp(color.scale)
+        color.func <- colorRamp(unique(color.scale)) # undo recycling in PrepareColors
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
             color.tmp <- as.numeric(group)

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -411,23 +411,26 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.func <- colorRamp(unique(color.scale)) # undo recycling in PrepareColors
+        color.scale <- unique(color.scale) # undo recycling in PrepareColors
+        color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
-            color.tmp <- as.numeric(group)
+            color.tmp <- unique(as.numeric(group)
         } else if (is.numeric(group)) {
-            color.tmp <- group
+            color.tmp <- unique(group)
         } else {
             tmp <- as.factor(group)
             color.levels <- levels(tmp)
             tmp.seq <- seq(from = 0, to = 1, length = nlevels(tmp))
             color.scale <- rgb(color.func(tmp.seq), maxColorValue = 255)
-            color.tmp <- as.numeric(tmp)
-            group <- color.tmp
+            color.tmp <- unique(as.numeric(tmp)
+            group <- as.numeric(tmp)
         }
+        color.min <- min(color.tmp, na.rm = TRUE)
+        color.max <- max(color.tmp, na.rm = TRUE)
 
         # Convert color variable to scale on 0 to 1
-        colors.scaled <- seq(from = 0, to = 1, length = length(color.levels))
+        colors.scaled <- (color.tmp - color.min)/(color.max - color.min)
         colors <- rgb(color.func(colors.scaled), maxColorValue = 255)
 
         # Use existing color interpolation to reduce the number

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -411,7 +411,6 @@ CombinedScatter <- function(
     color.levels <- NULL
     color.is.date.time <- FALSE
     if (!is.null(color.scale)) {
-        color.scale <- unique(color.scale) # undo recycling in PrepareColors
         color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -425,11 +425,9 @@ CombinedScatter <- function(
             color.tmp <- as.numeric(tmp)
             group <- color.tmp
         }
-        color.min <- min(color.tmp, na.rm = TRUE)
-        color.max <- max(color.tmp, na.rm = TRUE)
 
         # Convert color variable to scale on 0 to 1
-        colors.scaled <- (color.tmp - color.min)/(color.max - color.min)
+        colors.scaled <- seq(from = 0, to = 1, length = length(color.levels))
         colors <- rgb(color.func(colors.scaled), maxColorValue = 255)
 
         # Use existing color interpolation to reduce the number

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -415,7 +415,7 @@ CombinedScatter <- function(
         color.func <- colorRamp(color.scale)
         color.is.date.time <- isDateTime(group)
         if (color.is.date.time) {
-            color.tmp <- unique(as.numeric(group)
+            color.tmp <- unique(as.numeric(group))
         } else if (is.numeric(group)) {
             color.tmp <- unique(group)
         } else {


### PR DESCRIPTION
The colors parameter should match the unique groups.

This fixes FS2-2771 (maybe it had nothing to do with filters or missing values) and also other outputs where the colors weren't matching.