### PR TITLE
DPI-2938 Package rhtmlCombinedScatter in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlCombinedScatter";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''An HTML widget that creates a labeled scatter plot.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+    jsonlite
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlCombinedScatter in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR